### PR TITLE
chore: bump node to latest lts version (18.16.1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17.6-alpine
+FROM node:18.16.1-alpine
 ENV NODE_ENV=production
 LABEL "repository"="https://github.com/patrickjahns/version-drafter-action" \
       "homepage"="https://github.com/patrickjahns/version-drafter-action" \


### PR DESCRIPTION
Bump Node to latest LTS version (18.16.1).

Github action using Node 12 will stop working on September 27th, see link below.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

> GitHub Actions: All Actions will begin running on Node16 instead of Node12
> 
> Node 12 has been out of support since [April 2022](https://github.com/nodejs/Release/#end-of-life-releases), as a result we have started the deprecation process of Node 12 for GitHub Actions. We plan to migrate all actions to run on Node16 by Summer 2023. We will monitor the progress of the migration and listen to the community for how things are going before we define a final date.
> To raise awareness of the upcoming change, we are adding a warning into workflows which contain Actions running on Node 12. This will come into effect starting on September 27th.
> 
> What you need to do
> For Actions maintainers: Update your actions to run on Node 16 instead of Node 12 ([Actions configuration settings](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions))
> For Actions users: Update your workflows with latest versions of the actions which runs on Node 16 ([Using versions for Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions))