### PR TITLE
chore: bump node to next lts version 20.14.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.16.1-alpine
+FROM node:20.14.0-alpine
 ENV NODE_ENV=production
 LABEL "repository"="https://github.com/patrickjahns/version-drafter-action" \
       "homepage"="https://github.com/patrickjahns/version-drafter-action" \


### PR DESCRIPTION
- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
- > Node 16 has reached its end of life, prompting us to initiate its deprecation process for GitHub Actions. Our plan is to transition all actions to run on Node 20 by Spring 2024